### PR TITLE
Explicitly return too many requests for blob write

### DIFF
--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -259,6 +259,8 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 			return gcerrors.NotFound
 		case http.StatusPreconditionFailed:
 			return gcerrors.FailedPrecondition
+		case http.StatusTooManyRequests:
+			return gcerrors.ResourceExhausted
 		}
 	}
 	return gcerrors.Unknown


### PR DESCRIPTION
When writing too many times to a blob, currently, the gocloud library
will return an "unknown" error response, which is hard to catch
